### PR TITLE
Adding git to images

### DIFF
--- a/6.Dockerfile
+++ b/6.Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:6
 LABEL maintainer "chuck.wilson@gmail.com"
 
-RUN yum install -y rpmdevtools gcc gcc-c++ autoconf automake make && \
+RUN yum install -y rpmdevtools gcc gcc-c++ autoconf automake make git && \
     mkdir -p /root/rpmbuild/{SOURCES,SPECS}

--- a/7.Dockerfile
+++ b/7.Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
 LABEL maintainer "chuck.wilson@gmail.com"
 
-RUN yum install -y rpmdevtools gcc gcc-c++ autoconf automake make && \
+RUN yum install -y rpmdevtools gcc gcc-c++ autoconf automake make git && \
     mkdir -p /root/rpmbuild/{SOURCES,SPECS}

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This repo contains simple Dockerfiles for building build containers for
 CentOS 6 and 7.
 
 It contains packages `rpm-build`, `rpmdevtools`, `gcc`, `gcc-c++`,
-`automake`, `autoconf`, and `make`.
+`automake`, `autoconf`, `make` and `git`.


### PR DESCRIPTION
One of my builds fetches the latest tag of a remote git repo using `git` which isn't available in these build images. 

Adding it.